### PR TITLE
DockerイメージのUpdate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM php:7.3.4-fpm-alpine
+FROM php:7.3.6-fpm-alpine
 
-RUN set -x && \
-  apk update && \
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+RUN set -ex && \
+  apk add --update-cache --no-cache --virtual=.build-dependencies tzdata && \
+  cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
+  echo "Asia/Tokyo" > /etc/timezone && \
+  apk del .build-dependencies && \
   apk add --no-cache libxml2 libxml2-dev curl curl-dev autoconf $PHPIZE_DEPS && \
   docker-php-ext-install opcache mysqli pdo pdo_mysql xml mbstring curl session tokenizer json && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  composer config -g repos.packagist composer https://packagist.jp && \
   composer global require hirak/prestissimo
 
 COPY ./config/php.ini /usr/local/etc/php/php.ini


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://github.com/nurse-senka/php-production-docker/issues/6

# PRのDoneの定義
- DockerイメージのタイムゾーンがAsia/Tokyoに変更されている事

# 変更点概要
タイムゾーンをAsia/Tokyoに変更

ついでに以下の変更も行った

- PHPのマイナーバージョンを最新安定版に更新
- 問題が起きた際に分かりやすいように `set -ex` を設定
- rootでもcomposerを実行出来るように COMPOSER_ALLOW_SUPERUSER を有効化
- composerのミラーサイトを日本国内の物に変更